### PR TITLE
Add translate client code (can't get tranlate API to work!)

### DIFF
--- a/IntlChat.xcodeproj/project.pbxproj
+++ b/IntlChat.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		641BA81A197F43A9001CB724 /* Chat.m in Sources */ = {isa = PBXBuildFile; fileRef = 641BA819197F43A9001CB724 /* Chat.m */; };
 		641BA81D197F43C6001CB724 /* Message.m in Sources */ = {isa = PBXBuildFile; fileRef = 641BA81C197F43C6001CB724 /* Message.m */; };
 		64687943197CDB5500D3B274 /* User.m in Sources */ = {isa = PBXBuildFile; fileRef = 64687942197CDB5500D3B274 /* User.m */; };
+		64F8A2871988695D00B8DC72 /* TranslateClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 64F8A2861988695D00B8DC72 /* TranslateClient.m */; };
 		974798C4197A64F700D14F88 /* Blue-1536x2048.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 974798C3197A64F700D14F88 /* Blue-1536x2048.jpg */; };
 		979E14011978D94200120CDD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 979E14001978D94200120CDD /* Foundation.framework */; };
 		979E14031978D94200120CDD /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 979E14021978D94200120CDD /* CoreGraphics.framework */; };
@@ -86,6 +87,8 @@
 		641BA81C197F43C6001CB724 /* Message.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Message.m; sourceTree = "<group>"; };
 		64687941197CDB5500D3B274 /* User.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = User.h; sourceTree = "<group>"; };
 		64687942197CDB5500D3B274 /* User.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = User.m; sourceTree = "<group>"; };
+		64F8A2851988695D00B8DC72 /* TranslateClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TranslateClient.h; sourceTree = "<group>"; };
+		64F8A2861988695D00B8DC72 /* TranslateClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TranslateClient.m; sourceTree = "<group>"; };
 		86E74D666DEF4BF7BE0D861F /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		974798C3197A64F700D14F88 /* Blue-1536x2048.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = "Blue-1536x2048.jpg"; path = "assets/Blue-1536x2048.jpg"; sourceTree = "<group>"; };
 		979E13FD1978D94200120CDD /* IntlChat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IntlChat.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -193,6 +196,8 @@
 				641BA81C197F43C6001CB724 /* Message.m */,
 				640717961981E6B20002C684 /* Language.h */,
 				640717971981E6B20002C684 /* Language.m */,
+				64F8A2851988695D00B8DC72 /* TranslateClient.h */,
+				64F8A2861988695D00B8DC72 /* TranslateClient.m */,
 			);
 			name = models;
 			sourceTree = "<group>";
@@ -520,6 +525,7 @@
 				97DB3321197C89BA00269951 /* FriendCell.m in Sources */,
 				640717981981E6B20002C684 /* Language.m in Sources */,
 				979E14451978D9C100120CDD /* LoginViewController.m in Sources */,
+				64F8A2871988695D00B8DC72 /* TranslateClient.m in Sources */,
 				979E146A197A5BA700120CDD /* ChatCell.m in Sources */,
 				979E14131978D94200120CDD /* AppDelegate.m in Sources */,
 				979E14381978D95D00120CDD /* ChatsViewController.m in Sources */,

--- a/IntlChat/TranslateClient.h
+++ b/IntlChat/TranslateClient.h
@@ -1,0 +1,18 @@
+//
+//  TranslateClient.h
+//  IntlChat
+//
+//  Created by Osvaldo Sabina on 7/29/14.
+//  Copyright (c) 2014 stephanimoroni. All rights reserved.
+//
+
+#import <AFNetworking/AFHTTPRequestOperation.h>
+
+@interface TranslateClient : AFHTTPRequestOperation
+
++ (TranslateClient *)instance;
+
+- (AFHTTPRequestOperation *)getTranslationForString: (NSString *)input fromLang: (NSString *)from toLang: (NSString *)to
+                                        withSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+                                            failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+@end

--- a/IntlChat/TranslateClient.m
+++ b/IntlChat/TranslateClient.m
@@ -1,0 +1,76 @@
+//
+//  TranslateClient.m
+//  IntlChat
+//
+//  Created by Osvaldo Sabina on 7/29/14.
+//  Copyright (c) 2014 stephanimoroni. All rights reserved.
+//
+
+#import "TranslateClient.h"
+
+#import <AFNetworking/AFHTTPRequestOperationManager.h>
+
+#define TRANSLATE_BASE_URL @"https://www.googleapis.com"
+
+@interface TranslateClient ()
+
+@property (strong,nonatomic) NSString *APIKey;
+
+@end
+
+@implementation TranslateClient
+
+static TranslateClient *instance;
+
++(TranslateClient *) instance {
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        instance = [[TranslateClient alloc] init];
+    });
+    
+    return instance;
+}
+
+- (AFHTTPRequestOperation *)getTranslationForString: (NSString *)input fromLang: (NSString *)from toLang: (NSString *)to
+                                              withSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+                                              failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure {
+
+    //Don't translate unnecessarily
+    if ([from isEqualToString:to]) {
+        success((AFHTTPRequestOperation *)nil, input);
+        return (AFHTTPRequestOperation *)nil;
+    }
+    
+    AFHTTPRequestOperationManager *manager = [AFHTTPRequestOperationManager manager];
+
+    //Example URL: https://www.googleapis.com/language/translate/v2?key=INSERT-YOUR-KEY&q=hello%20world&source=en&target=de
+    NSString *inputEsc = [input stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    // Should be escaping from and to if we didn't totally control what they might be...
+    NSDictionary *params = @{ @"source" : from,
+                              @"target" : to,
+                              @"key" : self.APIKey,
+                              @"q" : inputEsc };
+
+    NSString *url = [NSString stringWithFormat:@"%@/language/translate/v2", TRANSLATE_BASE_URL];
+    //    manager.responseSerializer.acceptableContentTypes = [NSSet setWithObject:@"text/html"];
+    NSLog(@"Making call with bundle identifier '%@'", [[NSBundle mainBundle] bundleIdentifier]);
+    return [manager GET:url parameters: params success:^(AFHTTPRequestOperation *operation, id responseObject) {
+        NSLog(@"JSON: %@", responseObject);
+        // This is where we'd manipulate the object to return whatever we wanted, probably a string
+        // and then return it instead of the object itself.
+        success(self, responseObject);
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        NSLog(@"Error: %@", error);
+        failure(self, error);
+    }];
+    
+}
+
+-(id) init {
+    self = [super init];
+    self.APIKey = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"GoogleAPIKey"];
+    return self;
+}
+
+@end


### PR DESCRIPTION
So I had this in this state by late last night.  I spent a while then and a bit today trying to get the Google Translate API to work.  I signed up for billing on multiple accounts and enabled a bunch of stuff but I can't get it to do anything but return a 403 (forbidden).

I finally decided to give up but I figured I might as well give you a pull req for the last bit of code to make this work if you can figure out how to get a working API key.

So, this _should_ all work, you'd just need to do this:
1. Get an account with a working GT API key (apparently the hard part).
2. Add this to your ~/.api_keys file:
   GOOGLE_API_KEY=<your working key here>
3. Modify getTranslationForString:... in TranslateClient to return just the translated string (or modify the calling code in ChatViewController.m to manipulate the returned object.
4. Profit!

Or alternatively try out one of the other translate APIs that are free.

I will probably try to mess with this a bit more but it will probably be after I get back to Atlanta (mid Aug).  Regardless, thanks for letting me share your project and I'd love to see it in the App Store!
